### PR TITLE
Remove #pragma once in cpp code

### DIFF
--- a/rosidl_typesupport_protobuf_c/src/to_ros_c_string.cpp
+++ b/rosidl_typesupport_protobuf_c/src/to_ros_c_string.cpp
@@ -17,8 +17,6 @@
  * ================================ Apache 2.0 =================================
  */
 
-#pragma once
-
 #include "rosidl_typesupport_protobuf_c/to_ros_c_string.hpp"
 
 namespace typesupport_protobuf_c

--- a/rosidl_typesupport_protobuf_c/src/wstring_conversion.cpp
+++ b/rosidl_typesupport_protobuf_c/src/wstring_conversion.cpp
@@ -17,8 +17,6 @@
  * ================================ Apache 2.0 =================================
  */
 
-#pragma once
-
 #include "rosidl_typesupport_protobuf_c/wstring_conversion.hpp"
 
 #include <cstring>


### PR DESCRIPTION
`#pragma once` is not supposed to be used in `.cpp` code. 