### PR TITLE
Bugfix : fixed build on ROS2 humble

### DIFF
--- a/rosidl_typesupport_protobuf_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_protobuf_cpp/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 find_package(ament_cmake_python REQUIRED)
 find_package(rosidl_typesupport_protobuf REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
+find_package(rosidl_runtime_cpp REQUIRED)
 
 ament_export_dependencies(rmw)
 ament_export_dependencies(rcutils)
@@ -58,6 +59,7 @@ ament_export_dependencies(rosidl_generator_c)
 ament_export_dependencies(rosidl_generator_cpp)
 ament_export_dependencies(rosidl_typesupport_interface)
 ament_export_dependencies(rosidl_typesupport_protobuf)
+ament_export_dependencies(rosidl_runtime_cpp)
 
 ament_export_include_directories(include)
 

--- a/rosidl_typesupport_protobuf_cpp/package.xml
+++ b/rosidl_typesupport_protobuf_cpp/package.xml
@@ -12,12 +12,14 @@
   <buildtool_depend>rosidl_generator_cpp</buildtool_depend>
   <buildtool_depend>rosidl_adapter_proto</buildtool_depend>
   <buildtool_depend>rosidl_typesupport_protobuf</buildtool_depend>
+  <buildtool_depend>rosidl_runtime_cpp</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_cpp</buildtool_export_depend>
   <buildtool_export_depend>rosidl_adapter_proto</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_protobuf</buildtool_export_depend>
+  <buildtool_export_depend>rosidl_runtime_cpp</buildtool_export_depend>
 
   <build_export_depend>rmw</build_export_depend>
 


### PR DESCRIPTION
Hello.
I was able to build `rosidl_typesupport_protobuf` on ROS2 humble.

The only problem I encountered was a "rosidl_runtime_cpp/bounded_vector.hpp not found" error.
It seems that the `rosidl_typesupport_protobuf_cpp package` needs `rosidl_runtime_cpp` when building the messages.
This is fixed in this small pull request.

Best regards
Giorgio