### PR TITLE
Bufix : fixed comment handling in .msg files

### DIFF
--- a/rosidl_adapter_proto/resource/msg.proto.em
+++ b/rosidl_adapter_proto/resource/msg.proto.em
@@ -38,7 +38,7 @@ for annotation in message.structure.annotations:
             and ("language" in annotation.value) \
             and (annotation.value["language"] == "comment") \
             and ("text" in annotation.value):
-        comment = "//" + re.sub(r"\\n", "\n//", annotation.value["text"])
+        comment = "//" + re.sub("\n", "\n// ", annotation.value["text"])
         break
 }@
 @[if comment != ""]@
@@ -119,7 +119,7 @@ for member in message.structure.members:
                 and ("language" in annotation.value) \
                 and (annotation.value["language"] == "comment") \
                 and ("text" in annotation.value):
-            member_dict["comment"] = "  //" + re.sub(r"\\n", "\n  //", annotation.value["text"])
+            member_dict["comment"] = "  //" + re.sub("\n", "\n  //", annotation.value["text"])
         if (annotation.name == "unit") and ("value" in annotation.value):
             member_dict["unit"] = annotation.value["value"]
 


### PR DESCRIPTION
I noticed that using ROS2 humble and Python 3.10, multiline comments in .msg files are not handled properly.

For example, this is how the [Bool.msg](https://github.com/ros2/common_interfaces/blob/humble/std_msgs/msg/Bool.msg) file is converted in IDL format and then protobuf format:

`Bool.idl`
```
// generated from rosidl_adapter/resource/msg.idl.em
// with input from std_msgs/msg/Bool.msg
// generated code does not contain a copyright notice


module std_msgs {
  module msg {
    @verbatim (language="comment", text=
      "This was originally provided as an example message." "\n"
      "It is deprecated as of Foxy" "\n"
      "It is recommended to create your own semantically meaningful message." "\n"
      "However if you would like to continue using this please use the equivalent in example_msgs.")
    struct Bool {
      boolean data;
    };
  };
};
```

`Bool.proto`
```
// generated from rosidl_adapter_proto/resource/idl.proto.em
// with input from std_msgs:msg/Bool.idl
// generated code does not contain a copyright notice

syntax = "proto3";

package std_msgs.msg.pb;

//This was originally provided as an example message.
It is deprecated as of Foxy
It is recommended to create your own semantically meaningful message.
However if you would like to continue using this please use the equivalent in example_msgs.
message Bool
{

  bool data = 234097369;
}
```

As can be seen, the multiline comments are not handled properly.

The reason why this bug was not noticed before might be that until now the code was tested only with single-line comments. Or something changed in the way comments are handled in one of the `rosidl_typesupport_protobuf` dependencies.