### PR TITLE
Sort generated imports to make sure that they are deterministic

### DIFF
--- a/rosidl_adapter_proto/resource/idl.proto.em
+++ b/rosidl_adapter_proto/resource/idl.proto.em
@@ -79,7 +79,7 @@ for already_imported_proto_file in already_imported:
     if already_imported_proto_file in proto_import_set:
         proto_import_set.remove(already_imported_proto_file)
 }@
-@[for import_proto_file_path in proto_import_set]@
+@[for import_proto_file_path in sorted(proto_import_set)]@
 import "@(import_proto_file_path)";
 @[end for]@
 @#


### PR DESCRIPTION
The main content is: 7c18368f33a813c8b79363d390c6e95de4e5deb0 

This builds on top of #26 which brings this package up to humble and non-EOL ROS distros which is where I'm developing and can test. 

It could be cherry picked as well. But I didn't want to submit it there when I couldn't test it. 