### PR TITLE
[Feature] Add support for ROS2 jazzy

### DIFF
--- a/.github/workflows/basic_ci.yaml
+++ b/.github/workflows/basic_ci.yaml
@@ -10,6 +10,7 @@ jobs:
         ros_distribution:
           - humble
           - iron
+          - jazzy
           - rolling
 
         # Define the Docker image(s) associated with each ROS distribution.
@@ -30,6 +31,10 @@ jobs:
           - docker_image: ubuntu:jammy
             ros_distribution: iron
 
+          # Jazzy Jalisco (May 2024 - May 2029)
+          - docker_image: ubuntu:jammy
+            ros_distribution: jazzy
+
           # Rolling Ridley (No End-Of-Life)
           - docker_image: ubuntu:jammy
             ros_distribution: rolling
@@ -47,3 +52,4 @@ jobs:
           package-name: rosidl_adapter_proto rosidl_typesupport_protobuf rosidl_typesupport_protobuf_cpp rosidl_typesupport_protobuf_c rosidl_typeadapter_protobuf_test
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/${{ matrix.ros_distribution }}/ros2.repos
+          import-token: ${{ secrets.GITHUB_TOKEN }}

--- a/rosidl_adapter_proto/CMakeLists.txt
+++ b/rosidl_adapter_proto/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 # ================================= Apache 2.0 =================================
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 project(rosidl_adapter_proto)
 

--- a/rosidl_adapter_proto/cmake/rosidl_adapt_proto_interfaces.cmake
+++ b/rosidl_adapter_proto/cmake/rosidl_adapt_proto_interfaces.cmake
@@ -16,7 +16,9 @@
 #
 # ================================= Apache 2.0 =================================
 
-cmake_policy(SET CMP0148 OLD)
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.27")
+  cmake_policy(SET CMP0148 OLD)
+endif()
 find_package(Protobuf CONFIG QUIET)
 if(NOT Protobuf_FOUND)
   find_package(Protobuf REQUIRED)

--- a/rosidl_adapter_proto/cmake/rosidl_adapt_proto_interfaces.cmake
+++ b/rosidl_adapter_proto/cmake/rosidl_adapt_proto_interfaces.cmake
@@ -16,6 +16,7 @@
 #
 # ================================= Apache 2.0 =================================
 
+cmake_policy(SET CMP0148 OLD)
 find_package(Protobuf CONFIG QUIET)
 if(NOT Protobuf_FOUND)
   find_package(Protobuf REQUIRED)

--- a/rosidl_adapter_proto/cmake/rosidl_adapt_proto_interfaces.cmake
+++ b/rosidl_adapter_proto/cmake/rosidl_adapt_proto_interfaces.cmake
@@ -16,9 +16,10 @@
 #
 # ================================= Apache 2.0 =================================
 
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.27")
-  cmake_policy(SET CMP0148 OLD)
-endif()
+if(POLICY CMP0148)
+   cmake_policy(SET CMP0148 OLD)
+ endif()
+ 
 find_package(Protobuf CONFIG QUIET)
 if(NOT Protobuf_FOUND)
   find_package(Protobuf REQUIRED)

--- a/rosidl_adapter_proto/cmake/rosidl_adapt_proto_interfaces.cmake
+++ b/rosidl_adapter_proto/cmake/rosidl_adapt_proto_interfaces.cmake
@@ -16,8 +16,36 @@
 #
 # ================================= Apache 2.0 =================================
 
-find_package(PythonInterp REQUIRED)
-if(NOT PYTHON_EXECUTABLE)
+find_package(Protobuf CONFIG QUIET)
+if(NOT Protobuf_FOUND)
+  find_package(Protobuf REQUIRED)
+endif()
+
+# Set the protoc Executable
+# Protoc path retrieval from target taken from the CMake find module code of Protobuf
+if(NOT Protobuf_PROTOC_EXECUTABLE AND TARGET protobuf::protoc)
+  get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
+    IMPORTED_LOCATION_RELEASE)
+  if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
+    get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
+      IMPORTED_LOCATION_RELWITHDEBINFO)
+  endif()
+  if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
+    get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
+      IMPORTED_LOCATION_MINSIZEREL)
+  endif()
+  if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
+    get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
+      IMPORTED_LOCATION_DEBUG)
+  endif()
+  if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
+    get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
+      IMPORTED_LOCATION_NOCONFIG)
+  endif()
+endif()
+
+find_package(Python COMPONENTS Interpreter)
+if(NOT Python_FOUND)
   message(FATAL_ERROR "Variable 'PYTHON_EXECUTABLE' must not be empty")
 endif()
 
@@ -53,8 +81,10 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${_target_dependencies}
   ADDITIONAL_FILES "${_proto_include_dirs}")
 
+include(CMakePrintHelpers)
+
 execute_process(
-  COMMAND "${PYTHON_EXECUTABLE}" "${rosidl_adapter_proto_BIN}"
+  COMMAND "${Python_EXECUTABLE}" "${rosidl_adapter_proto_BIN}"
   --generator-arguments-file "${generator_arguments_file}"
   --protoc-path "${Protobuf_PROTOC_EXECUTABLE}"
   ERROR_VARIABLE error

--- a/rosidl_adapter_proto/cmake/rosidl_adapter_proto-extras.cmake.in
+++ b/rosidl_adapter_proto/cmake/rosidl_adapter_proto-extras.cmake.in
@@ -2,7 +2,10 @@
 # rosidl_adapter_proto/
 #   rosidl_adapter_proto-extras.cmake.in
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG QUIET)
+if(NOT Protobuf_FOUND)
+  find_package(Protobuf REQUIRED)
+endif()
 
 if(NOT Protobuf_FOUND)
   message(STATUS "Could not find Protobuf - skip rosidl_adapter_proto")

--- a/rosidl_typeadapter_protobuf_test/CMakeLists.txt
+++ b/rosidl_typeadapter_protobuf_test/CMakeLists.txt
@@ -2,13 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rosidl_typeadapter_protobuf_test)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-missing-field-initializers)
 endif()
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND MSVC)
   # /bigobj is needed to avoid error C1128:
@@ -109,6 +104,7 @@ if(BUILD_TESTING)
 
   function(custom_executable  target)
     add_executable(${target} ${ARGN})
+    target_compile_features(${target} PRIVATE cxx_std_14)
     ament_target_dependencies(${target}
       "rclcpp"
       "rclcpp_action"
@@ -124,9 +120,12 @@ if(BUILD_TESTING)
     "rclcpp"
     "test_msgs")
 
+  target_compile_features(subscribe_types PRIVATE cxx_std_14)
+
   # publisher combined with a subscriber
   custom_executable(test_proto_typeadapt_cpp
     "test/test_proto_typeadapt.cpp")
+  target_compile_features(test_proto_typeadapt_cpp PRIVATE cxx_std_14)
   target_link_libraries(test_proto_typeadapt_cpp subscribe_types rcpputils::rcpputils)
 
 

--- a/rosidl_typesupport_protobuf_c/CMakeLists.txt
+++ b/rosidl_typesupport_protobuf_c/CMakeLists.txt
@@ -27,18 +27,8 @@ else()
     CACHE BOOL "If Protobuf Static should be disabled.")
 endif()
 
-# Default to C99
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-missing-field-initializers)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
@@ -84,6 +74,7 @@ if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "ROSIDL_TYPESUPPORT_PROTOBUF_C_BUILDING_DLL")
 endif()
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14 c_std_99)
 
 # TODO(tfoote) This needs cpp to build due to
 # https://github.com/tfoote/rosidl_typesupport_protobuf/blob/132668ae385163ee8b45ce45a9022654e5c77666/

--- a/rosidl_typesupport_protobuf_c/cmake/rosidl_typesupport_protobuf_c-extras.cmake.in
+++ b/rosidl_typesupport_protobuf_c/cmake/rosidl_typesupport_protobuf_c-extras.cmake.in
@@ -1,7 +1,10 @@
 # generated from
 # rosidl_typesupport_protobuf_c/rosidl_typesupport_protobuf_c-extras.cmake.in
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG QUIET)
+if(NOT Protobuf_FOUND)
+  find_package(Protobuf REQUIRED)
+endif()
 
 if(NOT Protobuf_FOUND)
   message(STATUS "Could not find Protobuf: skipping rosidl_typesupport_protobuf_c")

--- a/rosidl_typesupport_protobuf_c/cmake/rosidl_typesupport_protobuf_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_protobuf_c/cmake/rosidl_typesupport_protobuf_c_generate_interfaces.cmake
@@ -16,7 +16,10 @@
 #
 # ================================= Apache 2.0 =================================
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG QUIET)
+if(NOT Protobuf_FOUND)
+  find_package(Protobuf REQUIRED)
+endif()
 
 find_package(rosidl_adapter_proto REQUIRED)
 find_package(rosidl_typesupport_protobuf REQUIRED)
@@ -93,8 +96,8 @@ if(rosidl_generate_interfaces_LIBRARY_NAME)
     PROPERTIES OUTPUT_NAME "${rosidl_generate_interfaces_LIBRARY_NAME}${_target_suffix}")
 endif()
 
-set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  PROPERTIES CXX_STANDARD 14
+target_compile_features(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  PRIVATE cxx_std_14
 )
 
 # Set flag for visibility macro
@@ -105,7 +108,7 @@ if(WIN32)
 endif()
 
 if(NOT WIN32)
-  set(_target_compile_flags "-Wall -Wextra -Wpedantic")
+  set(_target_compile_flags "-Wall -Wextra -Wpedantic -Wno-missing-field-initializers")
 else()
   set(_target_compile_flags "/W4")
 endif()
@@ -152,9 +155,15 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
     ${${_pkg_name}_LIBRARIES${_target_suffix}})
 endforeach()
 
-target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  ${Protobuf_LIBRARY}
-)
+if(protobuf_MODULE_COMPATIBLE) #Legacy mode
+  target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ${Protobuf_LIBRARY}
+  )
+else()
+  target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    protobuf::libprotobuf
+  )
+endif()
 
 add_dependencies(
   ${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_protobuf_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_protobuf_cpp/CMakeLists.txt
@@ -27,12 +27,8 @@ else()
     CACHE BOOL "If Protobuf Static should be disabled.")
 endif()
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-missing-field-initializers)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
@@ -66,6 +62,8 @@ ament_python_install_package(${PROJECT_NAME})
 add_library(${PROJECT_NAME} SHARED
   src/identifier.cpp
   src/wstring_conversion.cpp)
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 
 if(WIN32)
   target_compile_definitions(${PROJECT_NAME}

--- a/rosidl_typesupport_protobuf_cpp/cmake/rosidl_typesupport_protobuf_cpp-extras.cmake.in
+++ b/rosidl_typesupport_protobuf_cpp/cmake/rosidl_typesupport_protobuf_cpp-extras.cmake.in
@@ -2,7 +2,10 @@
 # rosidl_typesupport_protobuf_cpp/
 #   rosidl_typesupport_protobuf_cpp-extras.cmake.in
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG QUIET)
+if(NOT Protobuf_FOUND)
+  find_package(Protobuf REQUIRED)
+endif()
 
 if(NOT Protobuf_FOUND)
   message(STATUS

--- a/rosidl_typesupport_protobuf_cpp/cmake/rosidl_typesupport_protobuf_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_protobuf_cpp/cmake/rosidl_typesupport_protobuf_cpp_generate_interfaces.cmake
@@ -16,7 +16,10 @@
 #
 # ================================= Apache 2.0 =================================
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG QUIET)
+if(NOT Protobuf_FOUND)
+  find_package(Protobuf REQUIRED)
+endif()
 
 find_package(rosidl_adapter_proto REQUIRED)
 find_package(rosidl_typesupport_protobuf REQUIRED)
@@ -118,8 +121,8 @@ if(rosidl_generate_interfaces_LIBRARY_NAME)
 endif()
 
 # set C++ standard
-set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  PROPERTIES CXX_STANDARD 14
+target_compile_features(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  PRIVATE cxx_std_14
 )
 
 # Set flag for visibility macro
@@ -131,7 +134,7 @@ endif()
 
 # Set compiler flags
 if(NOT WIN32)
-  set(_target_compile_flags "-Wall -Wextra -Wpedantic")
+  set(_target_compile_flags "-Wall -Wextra -Wpedantic -Wno-missing-field-initializers")
 else()
   set(_target_compile_flags "/W4")
 endif()
@@ -166,7 +169,15 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
     ${${_pkg_name}_LIBRARIES${_target_suffix}})
 endforeach()
 
-target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} ${Protobuf_LIBRARY})
+if(protobuf_MODULE_COMPATIBLE) #Legacy mode
+  target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ${Protobuf_LIBRARY}
+  )
+else()
+  target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    protobuf::libprotobuf
+  )
+endif()
 
 # Make top level generation target depend on this library
 add_dependencies(


### PR DESCRIPTION
I updated, fixed and revamped the CMake files to be compatible with ROS2 Jazzy and any recent version of protobuf.
I double checked that everything works in the following 4 combinations:
- ROS2 humble
- ROS2 jazzy
- Protobuf v23
- Protobuf v27

If you want, I could also push the shell scripts and VSCode configuration I used for troubleshooting the build.